### PR TITLE
Fixed Uncaught TypeError and added maxHeight unit

### DIFF
--- a/angular-equalizer.js
+++ b/angular-equalizer.js
@@ -17,12 +17,12 @@
           }
           for (_j = 0, _len1 = item.length; _j < _len1; _j++) {
             i = item[_j];
-            maxHeight = Math.max(maxHeight, i.element.outerHeight());
+            maxHeight = Math.max(maxHeight, angular.element(i.element).prop('offsetHeight'));
           }
           if (maxHeight > 0) {
             for (_k = 0, _len2 = item.length; _k < _len2; _k++) {
               i = item[_k];
-              i.element.css('minHeight', maxHeight);
+              i.element.css('minHeight', maxHeight+'px');
             }
           }
         };


### PR DESCRIPTION
The code wasn't working when used it straight out of the box, even though latest jQuery and other mentioned plugins were provided. I updated missing outerHeight() with its angular fallback and then added 'px' to minHeight css declaration as offsetHeight provides the value without unit suffix.