### PR TITLE
Fix : the condition, a check that the variable 'i' is well defined

### DIFF
--- a/angular-equalizer.js
+++ b/angular-equalizer.js
@@ -64,7 +64,7 @@
                 EqualizerState.prototype.remove = function (group, element) {
                     var _this = this;
                     _.forEach(this.items[group], function (i, key) {
-                        if (i.element === element) {
+                        if (i && i.element === element) {
                             element.css({
                                 'minHeight': i.minHeight,
                                 'height': i.height


### PR DESCRIPTION
We have a property undefined in this function :

`EqualizerState.prototype.remove = function (group, element) { var _this = this; _.forEach(this.items[group], function (i, key) { if (i.element === element) { element.css({ 'minHeight': i.minHeight, 'height': i.height }); _this.items[group].splice(key, 1); return false; } }); return this; };`

Line 4 i is not defined

Browser error:

> TypeError: Cannot read property 'element' of undefined
> at angular-equalizer.js:67
> at Function.m.each.m.forEach (underscore.js:153)
> at EqualizerState.remove (angular-equalizer.js:66)
> at HTMLDivElement. (angular-equalizer.js:93)
> at HTMLDivElement.n.event.dispatch (jquery.min.js:3)
> at HTMLDivElement.r.handle (jquery.min.js:3)
> at Object.n.event.trigger (jquery.min.js:3)
> at n.fn.extend.triggerHandler (jquery.min.js:3)
> at Function.pa.fn.on.pa.cleanData (angular.js:1793)
> at Ia (jquery.min.js:3)

To solve this problem, our team added in the condition, a check that the variable 'i' is well defined.
Can you correct this problem on your repository.
RESOLVE
`EqualizerState.prototype.remove = function (group, element) { var _this = this; _.forEach(this.items[group], function (i, key) { if (i && i.element === element) { element.css({ 'minHeight': i.minHeight, 'height': i.height }); _this.items[group].splice(key, 1); return false; } }); return this; };`
